### PR TITLE
Change wikiUrl from 'http' to 'https'

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -49,7 +49,7 @@ function loadData() {
   });
 
   //do $.ajax and add wikipedia articles
-  var wikiUrl = 'http://en.wikipedia.org/w/api.php?action=opensearch&search=' + city + '&format=json&callback=wikiCallback';
+  var wikiUrl = 'https://en.wikipedia.org/w/api.php?action=opensearch&search=' + city + '&format=json&callback=wikiCallback';
   // console.log('wikiUrl: ' + wikiUrl);
 
   // create a setTimeout to handle errors


### PR DESCRIPTION
Error:
jquery.min.js:4 Mixed Content: The page at
'https://sliqric7053.github.io/Move-Planner-App/' was loaded over
HTTPS, but requested an insecure script
'http://en.wikipedia.org/w/api.php?action=opensearch&search=new%20york&f
orma…allback&callback=jQuery111109876225151960307_1471939626260&_=147193
9626261'. This request has been blocked; the content must be served
over HTTPS.
